### PR TITLE
Add GitHub Pages deployment workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,32 @@
+name: Build and Deploy
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v1
+      - run: bun install
+      - run: bun run build
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: ./dist
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ A secure personal recipe collection web application built for Gideon's mini proj
 - Real-time data persistence
 
 ## Development
+
 ```bash
 # Install dependencies
 bun install
@@ -30,38 +31,8 @@ bun run dev
 
 # Build for production
 bun run build
-cat > README.md << 'EOF'
-# Personal Recipe Collection App
+```
 
-A secure personal recipe collection web application built for Gideon's mini project requirements.
+## Deployment
 
-## Tech Stack
-
-- **TanStack Router** - Client-side routing
-- **Bun** - JavaScript runtime
-- **Railway** - Hosting platform
-- **Descope** - Authentication
-- **ShadCN/UI** - Modern UI components
-- **Convex** - Real-time database
-- **TailwindCSS** - Styling
-
-## Features
-
-- Secure user authentication
-- Create, edit, and delete recipes
-- Organize recipes by category
-- Clean, modern interface
-- Real-time data persistence
-
-## Development
-```bash
-# Install dependencies
-bun install
-
-# Start development server
-bun run dev
-
-# Build for production
-bun run build
-pwd
-ls -la
+The included GitHub Actions workflow runs `bun run build` (triggering `bunx convex codegen`) and deploys the generated `dist/` folder to GitHub Pages.


### PR DESCRIPTION
## Summary
- build project with `bun run build` before deploying
- publish the generated `dist/` folder to GitHub Pages

## Testing
- `bun run build`


------
https://chatgpt.com/codex/tasks/task_e_68c661d5b804832ca4943ed5d72c5e36