### PR TITLE
Redirect to root and honor next param after login

### DIFF
--- a/src/routes/App.tsx
+++ b/src/routes/App.tsx
@@ -2,10 +2,10 @@
 import { createFileRoute, redirect } from '@tanstack/react-router'
 
 // Light guard: look for Descope session (stored by their SDK)
-export const Route = createFileRoute('/app')({
+export const Route = createFileRoute('/App')({
   beforeLoad: () => {
     const authed = !!localStorage.getItem('DS') // Descope stores session here
-    if (!authed) throw redirect({ to: '/login', search: { next: '/app' } })
+    if (!authed) throw redirect({ to: '/', search: { next: '/App' } })
   },
   component: () => <Outlet />,
 })

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -3,6 +3,7 @@ import { useSession, useUser, useDescope } from '@descope/react-sdk'
 import { useQuery } from 'convex/react'
 import { api } from '../../convex/_generated/api.js'
 import { LoginPage } from '../components/LoginPage'
+import { useEffect } from 'react'
 
 export const Route = createFileRoute('/')({
   component: HomePage,
@@ -12,12 +13,20 @@ function HomePage() {
   const { isAuthenticated, isSessionLoading } = useSession()
   const { user, isUserLoading } = useUser()
   const { logout } = useDescope()
+  const navigate = Route.useNavigate()
+  const search = Route.useSearch<{ next?: string }>()
   
   // Simple test query
   const userId = (user as any)?.sub || (user as any)?.id || user?.email
-  const recipes = useQuery(api.recipes.getByUser, 
+  const recipes = useQuery(api.recipes.getByUser,
     isAuthenticated && userId ? { userId: userId } : "skip"
   )
+
+  useEffect(() => {
+    if (isAuthenticated && search.next) {
+      navigate({ to: search.next })
+    }
+  }, [isAuthenticated, search.next, navigate])
 
   if (isSessionLoading || isUserLoading) {
     return <div className="min-h-screen flex items-center justify-center">Loading...</div>


### PR DESCRIPTION
## Summary
- Redirect unauthenticated /App visits to root while preserving intended destination
- Navigate to the `next` query param after successful authentication on the home page

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68c661abb71c832c969c0a84fcbb76b7